### PR TITLE
Handle unexpected report keys such as those that include 'latest'

### DIFF
--- a/core/list_test.go
+++ b/core/list_test.go
@@ -31,6 +31,11 @@ func TestExtractReportTime(t *testing.T) {
 			ExpectedTime: parseTime("2021-11-30-2350"),
 			ExpectedErr:  false,
 		},
+		`valid resource access summary file - latest`: {
+			Key:          `customers/C10001/reports/aws/139710491120/latest/principal-access-summaries.latest.csv`,
+			ExpectedTime: TimeLatest,
+			ExpectedErr:  false,
+		},
 	}
 	for l, c := range cases {
 		actualTime, err := extractReportTimeFromKey(c.Key)

--- a/core/list_test.go
+++ b/core/list_test.go
@@ -1,0 +1,24 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExtractReportTime(t *testing.T) {
+	//customers/C10001/reports/aws/139710491120/2021/05/resources.2021-05-30-0750.csv
+	//customers/C10001/reports/aws/139710491120/2021/05/principals.2021-05-30-0750.csv
+	//customers/C10001/reports/aws/139710491120/2021/06/principals.2021-06-08-0755.csv
+	//customers/C10001/reports/aws/139710491120/2021/05/resource-access-summaries.2021-05-30-0750.csv
+	//customers/C10001/reports/aws/139710491120/2021/05/principal-access-summaries.2021-05-30-0750.csv
+	reportTime, err := extractReportTimeFromKey("customers/C10001/reports/aws/139710491120/2021/05/resources.2021-05-30-0750.csv")
+	if err != nil {
+		t.Fatalf(`Expected err to be nil, was %v`, err)
+	}
+
+	expectTime, _ := time.Parse("2006-01-02-1504", "2021-05-30-0751")
+
+	if expectTime != reportTime {
+		t.Fatalf(`Expected report time to be %v, but was %v`, expectTime, reportTime)
+	}
+}

--- a/core/list_test.go
+++ b/core/list_test.go
@@ -11,14 +11,48 @@ func TestExtractReportTime(t *testing.T) {
 	//customers/C10001/reports/aws/139710491120/2021/06/principals.2021-06-08-0755.csv
 	//customers/C10001/reports/aws/139710491120/2021/05/resource-access-summaries.2021-05-30-0750.csv
 	//customers/C10001/reports/aws/139710491120/2021/05/principal-access-summaries.2021-05-30-0750.csv
-	reportTime, err := extractReportTimeFromKey("customers/C10001/reports/aws/139710491120/2021/05/resources.2021-05-30-0750.csv")
-	if err != nil {
-		t.Fatalf(`Expected err to be nil, was %v`, err)
+	cases := map[string]struct {
+		Key          string
+		ExpectedTime time.Time
+		ExpectedErr  bool
+	}{
+		`valid resources file - fully qualified dt`: {
+			Key:          `customers/C10001/reports/aws/139710491120/2021/05/resources.2021-05-30-0750.csv`,
+			ExpectedTime: parseTime("2021-05-30-0750"),
+			ExpectedErr:  false,
+		},
+		`valid principals file - fully qualified dt`: {
+			Key:          `customers/C10001/reports/aws/139710491120/2021/06/principals.2021-06-11-1755.csv`,
+			ExpectedTime: parseTime("2021-06-11-1755"),
+			ExpectedErr:  false,
+		},
+		`valid principal access summary file - fully qualified dt`: {
+			Key:          `customers/C10001/reports/aws/139710491120/2021/11/principal-access-summaries.2021-11-30-2350.csv`,
+			ExpectedTime: parseTime("2021-11-30-2350"),
+			ExpectedErr:  false,
+		},
 	}
+	for l, c := range cases {
+		actualTime, err := extractReportTimeFromKey(c.Key)
+		if err != nil {
+			t.Fatalf(`ExpectedTime err to be nil, was %v`, err)
+		}
 
-	expectTime, _ := time.Parse("2006-01-02-1504", "2021-05-30-0751")
+		if c.ExpectedTime != actualTime {
+			t.Errorf("Case: %v, expected report time to be %v, but was %v", l, c.ExpectedTime, actualTime)
+		}
 
-	if expectTime != reportTime {
-		t.Fatalf(`Expected report time to be %v, but was %v`, expectTime, reportTime)
+		if err == nil && c.ExpectedErr {
+			t.Errorf("Case: %v, missing expected error", l)
+		}
+		if err != nil && !c.ExpectedErr {
+			t.Errorf("Case: %v, unexpected error: %v", l, err)
+		}
+
 	}
+}
+
+func parseTime(timeStr string) time.Time {
+	t, _ := time.Parse(FILENAME_TIMESTAMP_LAYOUT, timeStr)
+	return t
 }


### PR DESCRIPTION
## Description
Handle report keys that are formatted in unexpected ways, such as those that include 'latest' (a feature in progress), e.g.

```
customers/C10001/reports/aws/139710491120/latest/principal-access-summaries.latest.csv
```

## How Has This Been Tested?
Extracted the report key handling function and wrote unit tests for existing and new behavior.  Executed `k9 list` command against k9 dev reports bucket, which has many reports including those for new features.

## How are existing users impacted? What migration steps/scripts do we need?
Not applicable.  cli has not been released to customers yet.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/k9securityio/k9cli/blob/main/CONTRIBUTING.md) guide
- [X] added unit tests
