### PR TITLE
Phase2/sync xlsx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,6 @@ clean:
 test:
 	go test -cover ./...
 
-
-test:
-	go test ./...
-
 lint:
 	@golangci-lint run #\
 		#-D errcheck -D deadcode -D varcheck -D unused \

--- a/cmd/debug_env.go
+++ b/cmd/debug_env.go
@@ -43,7 +43,7 @@ var debugEnvCmd = &cobra.Command{
 		bucket, _ := cmd.Flags().GetString(`bucket`)
 		if len(bucket) > 0 {
 			client := s3.NewFromConfig(cfg)
-			s3db, err := core.LoadS3DB(client, bucket)
+			s3db, err := core.LoadS3DB(client, bucket, core.ReportTypeSelector{core.EXT_CSV, core.EXT_XLSX})
 			if err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Unable to load s3 database, %v\n", err)
 			} else {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -91,6 +91,8 @@ func init() {
 
 	syncCmd.Flags().String(`account`, ``, `AWS account for which reports will be downloaded`)
 	syncCmd.Flags().Bool(`dryrun`, false, `don't perform the download`)
+	syncCmd.Flags().Bool(`xlsx`, false, `download Excel sheets as well`)
+	syncCmd.Flags().Bool(`xlsx-only`, false, `only download Excel sheets`)
 
 	viper.BindPFlag(`account`, syncCmd.Flags().Lookup(`account`))
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,6 +45,7 @@ var syncCmd = &cobra.Command{
 		concurrency, _ := cmd.Flags().GetInt(`concurrency`)
 		verbose, _ := cmd.Flags().GetBool(`verbose`)
 		dryrun, _ := cmd.Flags().GetBool(`dryrun`)
+		xlsx, _ := cmd.Flags().GetBool(`include-xlsx`)
 		stdout := cmd.OutOrStdout()
 		stderr := cmd.ErrOrStderr()
 
@@ -55,7 +56,11 @@ var syncCmd = &cobra.Command{
 			return
 		}
 
-		s3db, err := core.LoadS3DB(s3.NewFromConfig(cfg), bucket)
+		selector := []string{core.EXT_CSV}
+		if xlsx {
+			selector = append(selector, core.EXT_XLSX)
+		}
+		s3db, err := core.LoadS3DB(s3.NewFromConfig(cfg), bucket, core.ReportTypeSelector(selector))
 		if err != nil {
 			fmt.Fprintf(stderr, "Error loading remote database: %v+\n", err)
 			os.Exit(1)
@@ -91,8 +96,7 @@ func init() {
 
 	syncCmd.Flags().String(`account`, ``, `AWS account for which reports will be downloaded`)
 	syncCmd.Flags().Bool(`dryrun`, false, `don't perform the download`)
-	syncCmd.Flags().Bool(`xlsx`, false, `download Excel sheets as well`)
-	syncCmd.Flags().Bool(`xlsx-only`, false, `only download Excel sheets`)
+	syncCmd.Flags().Bool(`include-xlsx`, false, `download Excel sheets as well`)
 
 	viper.BindPFlag(`account`, syncCmd.Flags().Lookup(`account`))
 

--- a/core/reports.go
+++ b/core/reports.go
@@ -77,6 +77,17 @@ func (r Report) ResourcesS3ObjectKey() string {
 	return r.reportS3ObjectKey(`resources`)
 }
 
+func (r Report) ResourceAccessAuditS3ObjectKey() string {
+	return fmt.Sprintf(
+		REPORT_LOCATION_XLSX_FQ_PATTERN,
+		r.CustomerID,
+		r.Account,
+		strconv.Itoa(r.Timestamp.Year()),
+		r.Timestamp.Format(MONTH_TIMESTAMP_LAYOUT),
+		`resource-access-audit`,
+		r.Timestamp.Format(FILENAME_TIMESTAMP_LAYOUT))
+}
+
 func (r Report) reportS3ObjectKey(name string) string {
 	return fmt.Sprintf(
 		REPORT_LOCATION_CSV_FQ_PATTERN,

--- a/core/strings.go
+++ b/core/strings.go
@@ -20,13 +20,15 @@ var (
 	REPORT_LOCATION_PREFIX           = `customers/`
 	REPORT_LOCATION_DELIMITER        = `/`
 	REPORT_LOCATION_CSV_FQ_PATTERN   = `customers/%s/reports/aws/%s/%s/%s/%s.%s.csv`
+	REPORT_LOCATION_XLSX_FQ_PATTERN  = `customers/%s/reports/aws/%s/%s/%s/%s.%s.xlsx`
 	REPORT_LOCATION_CUSTOMER_PATTERN = `customers/%s/reports/aws/`
 	REPORT_LOCATION_ACCOUNT_PATTERN  = `customers/%s/reports/aws/%s/`
 	REPORT_LOCATION_MONTH_PATTERN    = `customers/%s/reports/aws/%s/%s/%s`
 )
 
 const (
-	EXT_CSV = `csv`
+	EXT_CSV  = `csv`
+	EXT_XLSX = `xlsx`
 )
 
 // report file name prefixes


### PR DESCRIPTION
## Description

Added `--include-xlsx` flag on `sync` subcommand. This flag changes the behavior of the `sync` subcommand to download `xlsx` files as well as `csv` files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Use.

## How are existing users impacted? What migration steps/scripts do we need?

No impact. This is a backwards compatible change.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/k9securityio/k9cli/blob/main/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
