### PR TITLE
[feature] implement query principals and query resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,48 @@ Sample output showing IAM admins, simplified by piping through `jq '.[] | .princ
 "k9-dev-appeng"
 ```
 
+### Query Principals at a Point in Time
+
+You can use the `k9` CLI to query the set of principals for an account at a point in time (or from the latest report).
+
+```sh
+k9 query principals \
+    --customer_id $K9_CUSTOMER_ID \
+    --account $K9_ACCOUNT_ID \
+    --analysis-date 2022-04-29
+```
+
+You can use a combination of the `arns` and `names` flags to qualify a list of exact matching records.
+
+```sh
+k9 query principals \
+    --customer_id $K9_CUSTOMER_ID \
+    --account $K9_ACCOUNT_ID \
+    --arns $SOME_ROLE_ARN,$SOME_USER_ARN --arns $ANOTHER_USER_ARN \
+    --names $A_ROLE_NAME
+```
+
+### Query Resources at a Point in Time
+
+You can use the `k9` CLI to query the set of resources for an account at a point in time (or from the latest report).
+
+```sh
+k9 query resources \
+    --customer_id $K9_CUSTOMER_ID \
+    --account $K9_ACCOUNT_ID \
+    --analysis-date 2022-04-29
+```
+
+You can use a combination of the `arns` and `names` flags to qualify a list of exact matching records.
+
+```sh
+k9 query resources \
+    --customer_id $K9_CUSTOMER_ID \
+    --account $K9_ACCOUNT_ID \
+    --arns $SOME_BUCKET_ARN,$SOME_MACHINE_ARN --arns $ANOTHER_BUCKET_ARN \
+    --names $A_KMS_KEY_NAME
+```
+
 ### Changes to Principals or Resources Over Time
 
 You can use the `k9` CLI to determine what has changed in an account! Run the following command to generate a diff report between a historical analysis date and the latest report.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ k9 query resources \
     --names $A_KMS_KEY_NAME
 ```
 
+### Answer Questions about Resource and Principal Access
+
+```sh
+k9 query resource-access \
+    --customer_id $K9_CUSTOMER_ID \
+    --account $K9_ACCOUNT_ID \
+```
+
+```sh
+k9 query principal-access \
+    --customer_id $K9_CUSTOMER_ID \
+    --account $K9_ACCOUNT_ID \
+```
+
 ### Changes to Principals or Resources Over Time
 
 You can use the `k9` CLI to determine what has changed in an account! Run the following command to generate a diff report between a historical analysis date and the latest report.

--- a/README.md
+++ b/README.md
@@ -170,12 +170,16 @@ k9 query resources \
 k9 query resource-access \
     --customer_id $K9_CUSTOMER_ID \
     --account $K9_ACCOUNT_ID \
+    --arns $SOME_BUCKET_ARN,$SOME_MACHINE_ARN --arns $ANOTHER_BUCKET_ARN \
+    --names $A_KMS_KEY_NAME
 ```
 
 ```sh
 k9 query principal-access \
     --customer_id $K9_CUSTOMER_ID \
     --account $K9_ACCOUNT_ID \
+    --arns $SOME_ROLE_ARN,$SOME_USER_ARN --arns $ANOTHER_USER_ARN \
+    --names $A_ROLE_NAME
 ```
 
 ### Changes to Principals or Resources Over Time

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -18,8 +18,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -27,9 +25,6 @@ import (
 var analyzeCmd = &cobra.Command{
 	Use:   `analyze`,
 	Short: `Start analysis on current configuration`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Please specify a target to analyze")
-	},
 }
 
 // init defines and wires flags

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -9,3 +9,18 @@ const (
 	// EnvPrefix defines the prefix that this program uses to distinguish its environment variables.
 	EnvPrefix = `K9`
 )
+
+const (
+	FLAG_CUSTOMER_ID   = `customer_id`
+	FLAG_VERBOSE       = `verbose`
+	FLAG_ACCOUNT       = `account`
+	FLAG_FORMAT        = `format`
+	FLAG_ANALYSIS_DATE = `analysis-date`
+	FLAG_REPORT_HOME   = `report-home`
+
+	FLAG_ARN  = `arn`
+	FLAG_ARNS = `arns`
+
+	FLAG_NAME  = `name`
+	FLAG_NAMES = `names`
+)

--- a/cmd/db_helpers.go
+++ b/cmd/db_helpers.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/k9securityio/k9-cli/core"
+)
+
+func DumpDBStats(o io.Writer, db *core.DB) {
+	customers, accounts, total := db.Sizes()
+	fmt.Fprintf(o, "Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates: \t%v\n",
+		customers, accounts, total)
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -18,8 +18,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -28,9 +26,6 @@ import (
 var diffCmd = &cobra.Command{
 	Use:   "diff",
 	Short: `Calculate the difference between a snapshot and last scan`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("diff called")
-	},
 }
 
 // init defines and wires flags

--- a/cmd/diff_resources.go
+++ b/cmd/diff_resources.go
@@ -40,7 +40,20 @@ var diffResourcesCmd = &cobra.Command{
 		reportHome, _ := cmd.Flags().GetString(`report-home`)
 		stdout := cmd.OutOrStdout()
 		stderr := cmd.ErrOrStderr()
-		DoDiffResources(stdout, stderr, reportHome, customerID, accountID, analysisDate, verbose)
+
+		if len(analysisDate) <= 0 {
+			fmt.Fprintln(stderr, `an analysis-date is required for comparison`)
+			os.Exit(1)
+			return
+		}
+
+		td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+		if err != nil {
+			fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
+			os.Exit(1)
+		}
+
+		DoDiffResources(stdout, stderr, reportHome, customerID, accountID, td, verbose)
 	},
 }
 
@@ -50,18 +63,19 @@ func init() {
 }
 
 // DoDiffResources
-func DoDiffResources(stdout, stderr io.Writer, reportHome, customerID, accountID, analysisDate string, verbose bool) {
+func DoDiffResources(stdout, stderr io.Writer, reportHome, customerID, accountID string, analysisDate time.Time, verbose bool) {
 	// load the local report database
 	db, err := core.LoadLocalDB(reportHome)
 	if err != nil {
 		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
 	}
 
 	// get the latest analysis
 	var latestReportPath, targetReportPath string
 
-	if qr := db.GetPathForCustomerAccountLatestKind(
-		customerID, accountID, core.REPORT_TYPE_PREFIX_RESOURCES); qr != nil {
+	if qr := db.GetPathForCustomerAccountTimeKind(
+		customerID, accountID, nil, core.REPORT_TYPE_PREFIX_RESOURCES); qr != nil {
 		latestReportPath = *qr
 	} else {
 		fmt.Fprintf(stderr,
@@ -73,21 +87,15 @@ func DoDiffResources(stdout, stderr io.Writer, reportHome, customerID, accountID
 
 	// get the target analysis
 	// determine the file name for the desired report
-	reportDateTime, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
-	if err != nil {
-		fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
-		os.Exit(1)
-		return
-	}
 	if qr := db.GetPathForCustomerAccountTimeKind(
-		customerID, accountID, reportDateTime,
+		customerID, accountID, &analysisDate,
 		core.REPORT_TYPE_PREFIX_RESOURCES); qr != nil {
 		targetReportPath = *qr
 	} else {
 		fmt.Fprintf(stderr,
 			"No such target report: %v, %v, %v, total records: %v\n",
 			customerID, accountID,
-			reportDateTime.Format(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT),
+			analysisDate.Format(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT),
 			db.Size())
 		os.Exit(1)
 		return
@@ -123,7 +131,7 @@ func DoDiffResources(stdout, stderr io.Writer, reportHome, customerID, accountID
 	if verbose {
 		fmt.Fprintf(stderr,
 			"Target Analysis: %v, records: %v\nLatest Analysis: %v, records: %v\n",
-			reportDateTime, len(latest), latest[0].AnalysisTime, len(target))
+			analysisDate, len(latest), latest[0].AnalysisTime, len(target))
 	}
 
 	// index on principal ARN for each ReportItem

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	//"github.com/spf13/viper"
+	"github.com/spf13/viper"
 )
 
 // queryCmd represents the query command
@@ -35,4 +35,14 @@ var queryCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(queryCmd)
+
+	queryCmd.PersistentFlags().String(FLAG_ANALYSIS_DATE, ``, `Use snapshot from the specified date in YYYY-MM-DD (required)`)
+
+	queryCmd.PersistentFlags().String(FLAG_FORMAT, `json`, `Output format [csv|json] (default: json)`)
+	viper.BindPFlag(`query_format`, queryResourceCmd.Flags().Lookup(FLAG_FORMAT))
+
+	queryCmd.PersistentFlags().String(FLAG_CUSTOMER_ID, ``, `K9 customer ID for analysis (required)`)
+	queryCmd.MarkPersistentFlagRequired(FLAG_CUSTOMER_ID)
+	queryCmd.PersistentFlags().String(FLAG_ACCOUNT, ``, `AWS account ID for analysis (required)`)
+	queryCmd.MarkPersistentFlagRequired(FLAG_ACCOUNT)
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -18,8 +18,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -28,9 +26,6 @@ import (
 var queryCmd = &cobra.Command{
 	Use:   "query",
 	Short: "Lookup the effect of last scanned access control configuration by kind",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Please specify a target to query")
-	},
 }
 
 func init() {

--- a/cmd/query_principal.go
+++ b/cmd/query_principal.go
@@ -113,7 +113,8 @@ func DoQueryPrincipal(stdout, stderr io.Writer,
 		os.Exit(1)
 		return
 	}
-	report, err := core.LoadPrincipalsReport(lf)
+	report := &core.PrincipalsReport{}
+	err = core.LoadReport(lf, report)
 	if err != nil {
 		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
 		os.Exit(1)
@@ -121,16 +122,16 @@ func DoQueryPrincipal(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report.Items))
 	}
 
 	if len(principals) <= 0 {
-		views.Display(stdout, stderr, format, report)
+		views.Display(stdout, stderr, format, report.Items)
 		return
 	}
 
 	results := []core.PrincipalsReportItem{}
-	for _, ri := range report {
+	for _, ri := range report.Items {
 		if _, ok := principals[ri.PrincipalARN]; ok {
 			results = append(results, ri)
 			continue

--- a/cmd/query_principal.go
+++ b/cmd/query_principal.go
@@ -74,6 +74,7 @@ func init() {
 	queryPrincipalCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of principal names to retrieve`)
 }
 
+// DoQueryPrincipal is the high-level query and filtering logic for querying principal reports. Externalized for testability.
 func DoQueryPrincipal(stdout, stderr io.Writer,
 	reportHome, customerID, accountID, analysisDate, format string,
 	verbose bool,

--- a/cmd/query_principal.go
+++ b/cmd/query_principal.go
@@ -89,12 +89,7 @@ func DoQueryPrincipal(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer func() {
-			total, accounts, customers := db.Sizes()
-			fmt.Fprintf(stderr,
-				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
-				customers, accounts, total)
-		}()
+		defer DumpDBStats(db)
 	}
 
 	// determine the file name for the desired report

--- a/cmd/query_principal.go
+++ b/cmd/query_principal.go
@@ -157,9 +157,11 @@ func DoQueryPrincipal(stdout, stderr io.Writer,
 	for _, ri := range report {
 		if _, ok := principals[ri.PrincipalARN]; ok {
 			results = append(results, ri)
+			continue
 		}
 		if _, ok := principals[ri.PrincipalName]; ok {
 			results = append(results, ri)
+			continue
 		}
 	}
 	views.Display(stdout, stderr, format, results)

--- a/cmd/query_principal.go
+++ b/cmd/query_principal.go
@@ -19,25 +19,148 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"time"
 
+	"github.com/k9securityio/k9-cli/core"
+	"github.com/k9securityio/k9-cli/views"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // queryPrincipalCmd represents the principal command
 var queryPrincipalCmd = &cobra.Command{
-	Use:   "principal",
-	Short: "Lookup one or more principals",
+	Use:     "principal",
+	Aliases: []string{"principals"},
+	Short:   "Lookup one or more principals",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("principal called")
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		stdout := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		principalsFilter := map[string]bool{}
+
+		if err != nil {
+			fmt.Fprintf(stderr, err.Error())
+			os.Exit(1)
+			return
+		}
+
+		for _, p := range arns {
+			principalsFilter[p] = true
+		}
+		for _, p := range names {
+			principalsFilter[p] = true
+		}
+
+		DoQueryPrincipal(stdout, stderr,
+			reportHome, customerID, accountID, analysisDate, format,
+			verbose,
+			principalsFilter)
+
 	},
 }
 
 func init() {
 	queryCmd.AddCommand(queryPrincipalCmd)
 
-	queryPrincipalCmd.Flags().String("format", `json`, `Output format [csv|json] (default: json)`)
-	viper.BindPFlag(`query_format`, queryPrincipalCmd.Flags().Lookup(`format`))
+	queryPrincipalCmd.Flags().StringSlice(FLAG_ARNS, []string{}, `A list of principal ARNs to retrieve`)
+	queryPrincipalCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of principal names to retrieve`)
+}
 
-	queryPrincipalCmd.Flags().StringArray("principal", []string{}, `A list of principals to include`)
+func DoQueryPrincipal(stdout, stderr io.Writer,
+	reportHome, customerID, accountID, analysisDate, format string,
+	verbose bool,
+	principals map[string]bool) {
+
+	// load the local report database
+	db, err := core.LoadLocalDB(reportHome)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		defer func() {
+			total, accounts, customers := db.Sizes()
+			fmt.Fprintf(stderr,
+				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
+				customers, accounts, total)
+		}()
+	}
+
+	// determine the file name for the desired report
+	var path *string
+	var reportDateTime time.Time
+	if len(analysisDate) <= 0 {
+		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_PRINCIPALS)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
+			os.Exit(1)
+			return
+		}
+	} else {
+		// parse the time
+		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+		if err != nil {
+			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
+			os.Exit(1)
+			return
+		}
+		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_PRINCIPALS)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
+			os.Exit(1)
+			return
+		}
+	}
+
+	if len(*path) <= 0 {
+		fmt.Fprintf(stderr,
+			"No such report: %v %v, total records: %v\n",
+			customerID, accountID, db.Size())
+		os.Exit(1)
+		return
+	}
+
+	// get the report
+	lf, err := os.Open(*path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	report, err := core.LoadPrincipalsReport(lf)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+	}
+
+	if len(principals) <= 0 {
+		views.Display(stdout, stderr, format, report)
+		return
+	}
+
+	results := []core.PrincipalsReportItem{}
+	for _, ri := range report {
+		if _, ok := principals[ri.PrincipalARN]; ok {
+			results = append(results, ri)
+		}
+		if _, ok := principals[ri.PrincipalName]; ok {
+			results = append(results, ri)
+		}
+	}
+	views.Display(stdout, stderr, format, results)
 }

--- a/cmd/query_principal.go
+++ b/cmd/query_principal.go
@@ -42,14 +42,19 @@ var queryPrincipalCmd = &cobra.Command{
 		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
 		stdout := cmd.OutOrStdout()
 		stderr := cmd.ErrOrStderr()
-		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
-		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		arns, _ := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, _ := cmd.Flags().GetStringSlice(FLAG_NAMES)
 		principalsFilter := map[string]bool{}
 
-		if err != nil {
-			fmt.Fprintf(stderr, err.Error())
-			os.Exit(1)
-			return
+		var reportDateTime *time.Time
+		if len(analysisDate) > 0 {
+			td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+			if err != nil {
+				fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
+				os.Exit(1)
+				return
+			}
+			reportDateTime = &td
 		}
 
 		for _, p := range arns {
@@ -60,7 +65,8 @@ var queryPrincipalCmd = &cobra.Command{
 		}
 
 		DoQueryPrincipal(stdout, stderr,
-			reportHome, customerID, accountID, analysisDate, format,
+			reportHome, customerID, accountID, format,
+			reportDateTime,
 			verbose,
 			principalsFilter)
 
@@ -76,7 +82,8 @@ func init() {
 
 // DoQueryPrincipal is the high-level query and filtering logic for querying principal reports. Externalized for testability.
 func DoQueryPrincipal(stdout, stderr io.Writer,
-	reportHome, customerID, accountID, analysisDate, format string,
+	reportHome, customerID, accountID, format string,
+	analysisDate *time.Time,
 	verbose bool,
 	principals map[string]bool) {
 
@@ -89,41 +96,14 @@ func DoQueryPrincipal(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer DumpDBStats(db)
+		defer DumpDBStats(stderr, &db)
 	}
 
 	// determine the file name for the desired report
-	var path *string
-	var reportDateTime time.Time
-	if len(analysisDate) <= 0 {
-		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_PRINCIPALS)
-		if path == nil || len(*path) <= 0 {
-			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
-			os.Exit(1)
-			return
-		}
-	} else {
-		// parse the time
-		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
-		if err != nil {
-			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
-			os.Exit(1)
-			return
-		}
-		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_PRINCIPALS)
-		if path == nil || len(*path) <= 0 {
-			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
-			os.Exit(1)
-			return
-		}
-	}
-
-	if len(*path) <= 0 {
-		fmt.Fprintf(stderr,
-			"No such report: %v %v, total records: %v\n",
-			customerID, accountID, db.Size())
+	path := db.GetPathForCustomerAccountTimeKind(customerID, accountID, analysisDate, core.REPORT_TYPE_PREFIX_PRINCIPALS)
+	if path == nil || len(*path) <= 0 {
+		fmt.Fprintf(stderr, "No report found for customer: %v account: %v date: %v\n", customerID, accountID, analysisDate)
 		os.Exit(1)
-		return
 	}
 
 	// get the report
@@ -141,7 +121,7 @@ func DoQueryPrincipal(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
 	}
 
 	if len(principals) <= 0 {

--- a/cmd/query_principalAccess.go
+++ b/cmd/query_principalAccess.go
@@ -28,7 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// queryPrincipalAccessCmd represents the principal command
+// queryPrincipalAccessCmd represents the principal-access command
 var queryPrincipalAccessCmd = &cobra.Command{
 	Use:     "principal-access",
 	Aliases: []string{"principals-access", `pas`, `principal-summary`},
@@ -73,6 +73,7 @@ func init() {
 	queryPrincipalAccessCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of principal names to retrieve`)
 }
 
+// DoQueryPrincipalAccessSummary is the high-level query and filtering logic for querying principal-access reports. Externalized for testability.
 func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 	reportHome, customerID, accountID, analysisDate, format string,
 	verbose bool,

--- a/cmd/query_principalAccess.go
+++ b/cmd/query_principalAccess.go
@@ -19,24 +19,147 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"time"
 
+	"github.com/k9securityio/k9-cli/core"
+	"github.com/k9securityio/k9-cli/views"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-// queryPrincipalAccessCmd represents the principal-access command
+// queryPrincipalAccessCmd represents the principal command
 var queryPrincipalAccessCmd = &cobra.Command{
-	Use:   "principal-access",
-	Short: "Lookup one or more principal-access summary",
+	Use:     "principal-access",
+	Aliases: []string{"principals-access", `pas`, `principal-summary`},
+	Short:   "Lookup access summaries by principal attributes.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("principal-access called")
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		stdout := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		principalsFilter := map[string]bool{}
+
+		if err != nil {
+			fmt.Fprintf(stderr, err.Error())
+			os.Exit(1)
+			return
+		}
+
+		for _, p := range arns {
+			principalsFilter[p] = true
+		}
+		for _, p := range names {
+			principalsFilter[p] = true
+		}
+
+		DoQueryPrincipalAccessSummary(stdout, stderr,
+			reportHome, customerID, accountID, analysisDate, format,
+			verbose,
+			principalsFilter)
 	},
 }
 
 func init() {
 	queryCmd.AddCommand(queryPrincipalAccessCmd)
 
-	queryPrincipalAccessCmd.Flags().String("format", `json`, `Output format [csv|json] (default: json)`)
-	viper.BindPFlag(`query_format`, queryPrincipalAccessCmd.Flags().Lookup(`format`))
-	queryPrincipalAccessCmd.Flags().StringArray("principal", []string{}, `A list of principals to include`)
+	queryPrincipalAccessCmd.Flags().StringSlice(FLAG_ARNS, []string{}, `A list of principal ARNs to retrieve`)
+	queryPrincipalAccessCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of principal names to retrieve`)
+}
+
+func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
+	reportHome, customerID, accountID, analysisDate, format string,
+	verbose bool,
+	principals map[string]bool) {
+
+	// load the local report database
+	db, err := core.LoadLocalDB(reportHome)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		defer func() {
+			total, accounts, customers := db.Sizes()
+			fmt.Fprintf(stderr,
+				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
+				customers, accounts, total)
+		}()
+	}
+
+	// determine the file name for the desired report
+	var path *string
+	var reportDateTime time.Time
+	if len(analysisDate) <= 0 {
+		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_PRINCIPAL_ACCESS_SUMMARIES)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
+			os.Exit(1)
+			return
+		}
+	} else {
+		// parse the time
+		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+		if err != nil {
+			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
+			os.Exit(1)
+			return
+		}
+		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_PRINCIPAL_ACCESS_SUMMARIES)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
+			os.Exit(1)
+			return
+		}
+	}
+
+	if len(*path) <= 0 {
+		fmt.Fprintf(stderr,
+			"No such report: %v %v, total records: %v\n",
+			customerID, accountID, db.Size())
+		os.Exit(1)
+		return
+	}
+
+	// get the report
+	lf, err := os.Open(*path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	report, err := core.LoadPrincipalAccessSummaryReport(lf)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+	}
+
+	if len(principals) <= 0 {
+		views.Display(stdout, stderr, format, report)
+		return
+	}
+
+	results := []core.PrincipalAccessSummaryReportItem{}
+	for _, ri := range report {
+		if _, ok := principals[ri.PrincipalARN]; ok {
+			results = append(results, ri)
+		}
+		if _, ok := principals[ri.PrincipalName]; ok {
+			results = append(results, ri)
+		}
+	}
+	views.Display(stdout, stderr, format, results)
 }

--- a/cmd/query_principalAccess.go
+++ b/cmd/query_principalAccess.go
@@ -88,12 +88,7 @@ func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer func() {
-			total, accounts, customers := db.Sizes()
-			fmt.Fprintf(stderr,
-				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
-				customers, accounts, total)
-		}()
+		defer DumpDBStats(db)
 	}
 
 	// determine the file name for the desired report

--- a/cmd/query_principalAccess.go
+++ b/cmd/query_principalAccess.go
@@ -42,14 +42,19 @@ var queryPrincipalAccessCmd = &cobra.Command{
 		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
 		stdout := cmd.OutOrStdout()
 		stderr := cmd.ErrOrStderr()
-		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
-		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		arns, _ := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, _ := cmd.Flags().GetStringSlice(FLAG_NAMES)
 		principalsFilter := map[string]bool{}
 
-		if err != nil {
-			fmt.Fprintf(stderr, err.Error())
-			os.Exit(1)
-			return
+		var reportDateTime *time.Time
+		if len(analysisDate) > 0 {
+			td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+			if err != nil {
+				fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
+				os.Exit(1)
+				return
+			}
+			reportDateTime = &td
 		}
 
 		for _, p := range arns {
@@ -60,7 +65,8 @@ var queryPrincipalAccessCmd = &cobra.Command{
 		}
 
 		DoQueryPrincipalAccessSummary(stdout, stderr,
-			reportHome, customerID, accountID, analysisDate, format,
+			reportHome, customerID, accountID, format,
+			reportDateTime,
 			verbose,
 			principalsFilter)
 	},
@@ -75,7 +81,8 @@ func init() {
 
 // DoQueryPrincipalAccessSummary is the high-level query and filtering logic for querying principal-access reports. Externalized for testability.
 func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
-	reportHome, customerID, accountID, analysisDate, format string,
+	reportHome, customerID, accountID, format string,
+	analysisDate *time.Time,
 	verbose bool,
 	principals map[string]bool) {
 
@@ -88,39 +95,13 @@ func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer DumpDBStats(db)
+		defer DumpDBStats(stderr, &db)
 	}
 
 	// determine the file name for the desired report
-	var path *string
-	var reportDateTime time.Time
-	if len(analysisDate) <= 0 {
-		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_PRINCIPAL_ACCESS_SUMMARIES)
-		if path == nil || len(*path) <= 0 {
-			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
-			os.Exit(1)
-			return
-		}
-	} else {
-		// parse the time
-		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
-		if err != nil {
-			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
-			os.Exit(1)
-			return
-		}
-		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_PRINCIPAL_ACCESS_SUMMARIES)
-		if path == nil || len(*path) <= 0 {
-			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
-			os.Exit(1)
-			return
-		}
-	}
-
-	if len(*path) <= 0 {
-		fmt.Fprintf(stderr,
-			"No such report: %v %v, total records: %v\n",
-			customerID, accountID, db.Size())
+	path := db.GetPathForCustomerAccountTimeKind(customerID, accountID, analysisDate, core.REPORT_TYPE_PREFIX_PRINCIPAL_ACCESS_SUMMARIES)
+	if path == nil || len(*path) <= 0 {
+		fmt.Fprintf(stderr, "No report found for customer: %v account: %v date: %v\n", customerID, accountID, analysisDate)
 		os.Exit(1)
 		return
 	}
@@ -140,7 +121,7 @@ func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
 	}
 
 	if len(principals) <= 0 {

--- a/cmd/query_principalAccess.go
+++ b/cmd/query_principalAccess.go
@@ -113,7 +113,8 @@ func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 		os.Exit(1)
 		return
 	}
-	report, err := core.LoadPrincipalAccessSummaryReport(lf)
+	report := &core.PrincipalAccessSummaryReport{}
+	err = core.LoadReport(lf, report)
 	if err != nil {
 		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
 		os.Exit(1)
@@ -121,16 +122,16 @@ func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report.Items))
 	}
 
 	if len(principals) <= 0 {
-		views.Display(stdout, stderr, format, report)
+		views.Display(stdout, stderr, format, report.Items)
 		return
 	}
 
 	results := []core.PrincipalAccessSummaryReportItem{}
-	for _, ri := range report {
+	for _, ri := range report.Items {
 		if _, ok := principals[ri.PrincipalARN]; ok {
 			results = append(results, ri)
 			continue

--- a/cmd/query_principalAccess.go
+++ b/cmd/query_principalAccess.go
@@ -156,9 +156,11 @@ func DoQueryPrincipalAccessSummary(stdout, stderr io.Writer,
 	for _, ri := range report {
 		if _, ok := principals[ri.PrincipalARN]; ok {
 			results = append(results, ri)
+			continue
 		}
 		if _, ok := principals[ri.PrincipalName]; ok {
 			results = append(results, ri)
+			continue
 		}
 	}
 	views.Display(stdout, stderr, format, results)

--- a/cmd/query_resource.go
+++ b/cmd/query_resource.go
@@ -89,12 +89,7 @@ func DoQueryResource(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer func() {
-			total, accounts, customers := db.Sizes()
-			fmt.Fprintf(stderr,
-				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
-				customers, accounts, total)
-		}()
+		defer DumpDBStats(db)
 	}
 
 	// determine the file name for the desired report

--- a/cmd/query_resource.go
+++ b/cmd/query_resource.go
@@ -114,7 +114,8 @@ func DoQueryResource(stdout, stderr io.Writer,
 		os.Exit(1)
 		return
 	}
-	report, err := core.LoadResourcesReport(lf)
+	report := &core.ResourcesReport{}
+	err = core.LoadReport(lf, report)
 	if err != nil {
 		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
 		os.Exit(1)
@@ -122,16 +123,16 @@ func DoQueryResource(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report.Items))
 	}
 
 	if len(resources) <= 0 {
-		views.Display(stdout, stderr, format, report)
+		views.Display(stdout, stderr, format, report.Items)
 		return
 	}
 
 	results := []core.ResourcesReportItem{}
-	for _, ri := range report {
+	for _, ri := range report.Items {
 		if _, ok := resources[ri.ResourceARN]; ok {
 			results = append(results, ri)
 			continue

--- a/cmd/query_resource.go
+++ b/cmd/query_resource.go
@@ -157,9 +157,11 @@ func DoQueryResource(stdout, stderr io.Writer,
 	for _, ri := range report {
 		if _, ok := resources[ri.ResourceARN]; ok {
 			results = append(results, ri)
+			continue
 		}
 		if _, ok := resources[ri.ResourceName]; ok {
 			results = append(results, ri)
+			continue
 		}
 	}
 	views.Display(stdout, stderr, format, results)

--- a/cmd/query_resource.go
+++ b/cmd/query_resource.go
@@ -74,6 +74,7 @@ func init() {
 	queryResourceCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of resource names to retrieve`)
 }
 
+// DoQueryResource is the high-level query and filtering logic for querying resource reports. Externalized for testability.
 func DoQueryResource(stdout, stderr io.Writer,
 	reportHome, customerID, accountID, analysisDate, format string,
 	verbose bool,

--- a/cmd/query_resource.go
+++ b/cmd/query_resource.go
@@ -19,24 +19,148 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"time"
 
+	"github.com/k9securityio/k9-cli/core"
+	"github.com/k9securityio/k9-cli/views"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // queryResourceCmd represents the resource command
 var queryResourceCmd = &cobra.Command{
-	Use:   "resource",
-	Short: "Lookup one or more resources",
+	Use:     "resource",
+	Aliases: []string{"resources"},
+	Short:   "Lookup one or more resources",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("resource called")
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		stdout := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		resourcesFilter := map[string]bool{}
+
+		if err != nil {
+			fmt.Fprintf(stderr, err.Error())
+			os.Exit(1)
+			return
+		}
+
+		for _, p := range arns {
+			resourcesFilter[p] = true
+		}
+		for _, p := range names {
+			resourcesFilter[p] = true
+		}
+
+		DoQueryResource(stdout, stderr,
+			reportHome, customerID, accountID, analysisDate, format,
+			verbose,
+			resourcesFilter)
+
 	},
 }
 
 func init() {
 	queryCmd.AddCommand(queryResourceCmd)
 
-	queryResourceCmd.Flags().String("format", `json`, `Output format [csv|json] (default: json)`)
-	viper.BindPFlag(`query_format`, queryResourceCmd.Flags().Lookup(`format`))
-	queryResourceCmd.Flags().StringArray("resource", []string{}, `A list of resource ARNs to include`)
+	queryResourceCmd.Flags().StringSlice(FLAG_ARNS, []string{}, `A list of resource ARNs to retrieve`)
+	queryResourceCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of resource names to retrieve`)
+}
+
+func DoQueryResource(stdout, stderr io.Writer,
+	reportHome, customerID, accountID, analysisDate, format string,
+	verbose bool,
+	resources map[string]bool) {
+
+	// load the local report database
+	db, err := core.LoadLocalDB(reportHome)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		defer func() {
+			total, accounts, customers := db.Sizes()
+			fmt.Fprintf(stderr,
+				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
+				customers, accounts, total)
+		}()
+	}
+
+	// determine the file name for the desired report
+	var path *string
+	var reportDateTime time.Time
+	if len(analysisDate) <= 0 {
+		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_RESOURCES)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
+			os.Exit(1)
+			return
+		}
+	} else {
+		// parse the time
+		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+		if err != nil {
+			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
+			os.Exit(1)
+			return
+		}
+		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_RESOURCES)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
+			os.Exit(1)
+			return
+		}
+	}
+
+	if len(*path) <= 0 {
+		fmt.Fprintf(stderr,
+			"No such report: %v %v, total records: %v\n",
+			customerID, accountID, db.Size())
+		os.Exit(1)
+		return
+	}
+
+	// get the report
+	lf, err := os.Open(*path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	report, err := core.LoadResourcesReport(lf)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+	}
+
+	if len(resources) <= 0 {
+		views.Display(stdout, stderr, format, report)
+		return
+	}
+
+	results := []core.ResourcesReportItem{}
+	for _, ri := range report {
+		if _, ok := resources[ri.ResourceARN]; ok {
+			results = append(results, ri)
+		}
+		if _, ok := resources[ri.ResourceName]; ok {
+			results = append(results, ri)
+		}
+	}
+	views.Display(stdout, stderr, format, results)
 }

--- a/cmd/query_resourceAccess.go
+++ b/cmd/query_resourceAccess.go
@@ -73,6 +73,7 @@ func init() {
 	queryResourceAccessCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of resource names to retrieve`)
 }
 
+// DoQueryResourceAccessSummary is the high-level query and filtering logic for querying resource-access reports. Externalized for testability.
 func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 	reportHome, customerID, accountID, analysisDate, format string,
 	verbose bool,

--- a/cmd/query_resourceAccess.go
+++ b/cmd/query_resourceAccess.go
@@ -88,12 +88,7 @@ func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer func() {
-			total, accounts, customers := db.Sizes()
-			fmt.Fprintf(stderr,
-				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
-				customers, accounts, total)
-		}()
+		defer DumpDBStats(db)
 	}
 
 	// determine the file name for the desired report

--- a/cmd/query_resourceAccess.go
+++ b/cmd/query_resourceAccess.go
@@ -19,24 +19,147 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"time"
 
+	"github.com/k9securityio/k9-cli/core"
+	"github.com/k9securityio/k9-cli/views"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // queryResourceAccessCmd represents the resource-access command
 var queryResourceAccessCmd = &cobra.Command{
-	Use:   "resource-access",
-	Short: "Lookup one or more resource access summaries",
+	Use:     "resource-access",
+	Aliases: []string{"resources-access", `pas`, `resource-summary`},
+	Short:   "Lookup access summaries by resource attributes.",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("resource-access called")
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		stdout := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		resourcesFilter := map[string]bool{}
+
+		if err != nil {
+			fmt.Fprintf(stderr, err.Error())
+			os.Exit(1)
+			return
+		}
+
+		for _, p := range arns {
+			resourcesFilter[p] = true
+		}
+		for _, p := range names {
+			resourcesFilter[p] = true
+		}
+
+		DoQueryResourceAccessSummary(stdout, stderr,
+			reportHome, customerID, accountID, analysisDate, format,
+			verbose,
+			resourcesFilter)
 	},
 }
 
 func init() {
 	queryCmd.AddCommand(queryResourceAccessCmd)
 
-	queryResourceAccessCmd.Flags().String("format", `json`, `Output format [csv|json] (default: json)`)
-	viper.BindPFlag(`query_format`, queryResourceAccessCmd.Flags().Lookup(`format`))
-	queryResourceAccessCmd.Flags().StringArray("resource", []string{}, `A list of resource ARNs to include`)
+	queryResourceAccessCmd.Flags().StringSlice(FLAG_ARNS, []string{}, `A list of resource ARNs to retrieve`)
+	queryResourceAccessCmd.Flags().StringSlice(FLAG_NAMES, []string{}, `A list of resource names to retrieve`)
+}
+
+func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
+	reportHome, customerID, accountID, analysisDate, format string,
+	verbose bool,
+	resources map[string]bool) {
+
+	// load the local report database
+	db, err := core.LoadLocalDB(reportHome)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		defer func() {
+			total, accounts, customers := db.Sizes()
+			fmt.Fprintf(stderr,
+				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates\t%v\n",
+				customers, accounts, total)
+		}()
+	}
+
+	// determine the file name for the desired report
+	var path *string
+	var reportDateTime time.Time
+	if len(analysisDate) <= 0 {
+		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_RESOURCE_ACCESS_SUMMARIES)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
+			os.Exit(1)
+			return
+		}
+	} else {
+		// parse the time
+		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+		if err != nil {
+			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
+			os.Exit(1)
+			return
+		}
+		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_RESOURCE_ACCESS_SUMMARIES)
+		if path == nil || len(*path) <= 0 {
+			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
+			os.Exit(1)
+			return
+		}
+	}
+
+	if len(*path) <= 0 {
+		fmt.Fprintf(stderr,
+			"No such report: %v %v, total records: %v\n",
+			customerID, accountID, db.Size())
+		os.Exit(1)
+		return
+	}
+
+	// get the report
+	lf, err := os.Open(*path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+	report, err := core.LoadResourceAccessSummaryReport(lf)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+		return
+	}
+
+	if verbose {
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+	}
+
+	if len(resources) <= 0 {
+		views.Display(stdout, stderr, format, report)
+		return
+	}
+
+	results := []core.ResourceAccessSummaryReportItem{}
+	for _, ri := range report {
+		if _, ok := resources[ri.ResourceARN]; ok {
+			results = append(results, ri)
+		}
+		if _, ok := resources[ri.ResourceName]; ok {
+			results = append(results, ri)
+		}
+	}
+	views.Display(stdout, stderr, format, results)
 }

--- a/cmd/query_resourceAccess.go
+++ b/cmd/query_resourceAccess.go
@@ -113,7 +113,8 @@ func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 		os.Exit(1)
 		return
 	}
-	report, err := core.LoadResourceAccessSummaryReport(lf)
+	report := &core.ResourceAccessSummaryReport{}
+	err = core.LoadReport(lf, report)
 	if err != nil {
 		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
 		os.Exit(1)
@@ -121,16 +122,16 @@ func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report.Items))
 	}
 
 	if len(resources) <= 0 {
-		views.Display(stdout, stderr, format, report)
+		views.Display(stdout, stderr, format, report.Items)
 		return
 	}
 
 	results := []core.ResourceAccessSummaryReportItem{}
-	for _, ri := range report {
+	for _, ri := range report.Items {
 		if _, ok := resources[ri.ResourceARN]; ok {
 			results = append(results, ri)
 			continue

--- a/cmd/query_resourceAccess.go
+++ b/cmd/query_resourceAccess.go
@@ -42,14 +42,19 @@ var queryResourceAccessCmd = &cobra.Command{
 		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
 		stdout := cmd.OutOrStdout()
 		stderr := cmd.ErrOrStderr()
-		arns, err := cmd.Flags().GetStringSlice(FLAG_ARNS)
-		names, err := cmd.Flags().GetStringSlice(FLAG_NAMES)
+		arns, _ := cmd.Flags().GetStringSlice(FLAG_ARNS)
+		names, _ := cmd.Flags().GetStringSlice(FLAG_NAMES)
 		resourcesFilter := map[string]bool{}
 
-		if err != nil {
-			fmt.Fprintf(stderr, err.Error())
-			os.Exit(1)
-			return
+		var reportDateTime *time.Time
+		if len(analysisDate) > 0 {
+			td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+			if err != nil {
+				fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
+				os.Exit(1)
+				return
+			}
+			reportDateTime = &td
 		}
 
 		for _, p := range arns {
@@ -60,7 +65,8 @@ var queryResourceAccessCmd = &cobra.Command{
 		}
 
 		DoQueryResourceAccessSummary(stdout, stderr,
-			reportHome, customerID, accountID, analysisDate, format,
+			reportHome, customerID, accountID, format,
+			reportDateTime,
 			verbose,
 			resourcesFilter)
 	},
@@ -75,7 +81,8 @@ func init() {
 
 // DoQueryResourceAccessSummary is the high-level query and filtering logic for querying resource-access reports. Externalized for testability.
 func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
-	reportHome, customerID, accountID, analysisDate, format string,
+	reportHome, customerID, accountID, format string,
+	analysisDate *time.Time,
 	verbose bool,
 	resources map[string]bool) {
 
@@ -88,39 +95,13 @@ func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		defer DumpDBStats(db)
+		defer DumpDBStats(stderr, &db)
 	}
 
 	// determine the file name for the desired report
-	var path *string
-	var reportDateTime time.Time
-	if len(analysisDate) <= 0 {
-		path = db.GetPathForCustomerAccountLatestKind(customerID, accountID, core.REPORT_TYPE_PREFIX_RESOURCE_ACCESS_SUMMARIES)
-		if path == nil || len(*path) <= 0 {
-			fmt.Fprintf(stderr, "No report found for customer: %v account: %v\n", customerID, accountID)
-			os.Exit(1)
-			return
-		}
-	} else {
-		// parse the time
-		reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
-		if err != nil {
-			fmt.Fprintf(stderr, "Invalid analysis-date: %v\n", analysisDate)
-			os.Exit(1)
-			return
-		}
-		path = db.GetPathForCustomerAccountTimeKind(customerID, accountID, reportDateTime, core.REPORT_TYPE_PREFIX_RESOURCE_ACCESS_SUMMARIES)
-		if path == nil || len(*path) <= 0 {
-			fmt.Fprintf(stderr, "No report found for customer: %v account: %v date:%v\n", customerID, accountID, analysisDate)
-			os.Exit(1)
-			return
-		}
-	}
-
-	if len(*path) <= 0 {
-		fmt.Fprintf(stderr,
-			"No such report: %v %v, total records: %v\n",
-			customerID, accountID, db.Size())
+	path := db.GetPathForCustomerAccountTimeKind(customerID, accountID, analysisDate, core.REPORT_TYPE_PREFIX_RESOURCE_ACCESS_SUMMARIES)
+	if path == nil || len(*path) <= 0 {
+		fmt.Fprintf(stderr, "No report found for customer: %v account: %v date: %v\n", customerID, accountID, analysisDate)
 		os.Exit(1)
 		return
 	}
@@ -140,7 +121,7 @@ func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 	}
 
 	if verbose {
-		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", reportDateTime, len(report))
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report))
 	}
 
 	if len(resources) <= 0 {

--- a/cmd/query_resourceAccess.go
+++ b/cmd/query_resourceAccess.go
@@ -156,9 +156,11 @@ func DoQueryResourceAccessSummary(stdout, stderr io.Writer,
 	for _, ri := range report {
 		if _, ok := resources[ri.ResourceARN]; ok {
 			results = append(results, ri)
+			continue
 		}
 		if _, ok := resources[ri.ResourceName]; ok {
 			results = append(results, ri)
+			continue
 		}
 	}
 	views.Display(stdout, stderr, format, results)

--- a/cmd/query_risks_privilegeEscalation.go
+++ b/cmd/query_risks_privilegeEscalation.go
@@ -63,6 +63,8 @@ func DoQueryRisksPrivilegeEscalation(stdout, stderr io.Writer, reportHome, custo
 	db, err := core.LoadLocalDB(reportHome)
 	if err != nil {
 		fmt.Printf("Unable to load local database, %v\n", err)
+		os.Exit(1)
+		return
 	}
 	if verbose {
 		defer func() {

--- a/cmd/query_risks_privilegeEscalation.go
+++ b/cmd/query_risks_privilegeEscalation.go
@@ -89,7 +89,8 @@ func DoQueryRisksPrivilegeEscalation(stdout, stderr io.Writer, reportHome, custo
 	}
 
 	// Open and load the report
-	records, err := core.LoadPrincipalsReport(f)
+	records := &core.PrincipalsReport{}
+	err = core.LoadReport(f, records)
 	if err != nil {
 		fmt.Fprintf(stderr, "Unable to analyze the specified report: %v\n", err)
 		os.Exit(1)
@@ -98,7 +99,7 @@ func DoQueryRisksPrivilegeEscalation(stdout, stderr io.Writer, reportHome, custo
 
 	// reducer - apply filtering or detective logic
 	output := []core.PrincipalsReportItem{}
-	for _, r := range records {
+	for _, r := range records.Items {
 		if r.PrincipalIsIAMAdmin {
 			output = append(output, r)
 		}

--- a/cmd/query_risks_privilegeEscalation.go
+++ b/cmd/query_risks_privilegeEscalation.go
@@ -34,30 +34,25 @@ var queryRisksPrivilegeEscalationCmd = &cobra.Command{
 	Aliases: []string{`iam-admins`},
 	Short:   "Show privilege escalation risks",
 	Run: func(cmd *cobra.Command, args []string) {
-		verbose, err := cmd.Flags().GetBool(FLAG_VERBOSE)
-		format, err := cmd.Flags().GetString(FLAG_FORMAT)
-		customerID, err := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
-		accountID, err := cmd.Flags().GetString(FLAG_ACCOUNT)
-		analysisDate, err := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
-		reportHome, err := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
 		stdout := cmd.OutOrStdout()
 		stderr := cmd.ErrOrStderr()
 
-		var reportDateTime time.Time
+		var reportDateTime *time.Time
 		if len(analysisDate) > 0 {
-			reportDateTime, err = time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+			td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
 			if err != nil {
-				err = fmt.Errorf("invalid analysis-date: %v\n", analysisDate)
+				fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
 			}
+			reportDateTime = &td
 		}
 
-		if err != nil {
-			fmt.Fprintf(stderr, err.Error())
-			os.Exit(1)
-			return
-		}
-
-		DoQueryRisksPrivilegeEscalation(stdout, stderr, reportHome, customerID, accountID, format, &reportDateTime, verbose)
+		DoQueryRisksPrivilegeEscalation(stdout, stderr, reportHome, customerID, accountID, format, reportDateTime, verbose)
 	},
 }
 

--- a/cmd/query_risks_privilegeEscalation.go
+++ b/cmd/query_risks_privilegeEscalation.go
@@ -67,12 +67,7 @@ func DoQueryRisksPrivilegeEscalation(stdout, stderr io.Writer, reportHome, custo
 		return
 	}
 	if verbose {
-		defer func() {
-			total, accounts, customers := db.Sizes()
-			fmt.Fprintf(stderr,
-				"Local database:\n\tCustomers:\t\t%v\n\tAccounts:\t\t%v\n\tTotal analysis dates: \t%v\n",
-				customers, accounts, total)
-		}()
+		defer DumpDBStats(db)
 	}
 
 	// determine the file name for the desired report

--- a/core/db.go
+++ b/core/db.go
@@ -66,7 +66,7 @@ func (db *DB) Sizes() (total int, accounts int, customers int) {
 	return
 }
 
-func (db *DB) GetPathForCustomerAccountTimeKind(customerID, accountID string, ts time.Time, kind string) *string {
+func (db *DB) GetPathForCustomerAccountTimeKind(customerID, accountID string, ts *time.Time, kind string) *string {
 	var (
 		customer Customer
 		account  Account
@@ -80,30 +80,11 @@ func (db *DB) GetPathForCustomerAccountTimeKind(customerID, accountID string, ts
 	if account, ok = customer.Accounts[accountID]; !ok {
 		return nil
 	}
-	if report, ok = account.Reports[ts.Truncate(24*time.Hour)]; !ok {
+	if ts == nil {
+		report = account.Latest()
+	} else if report, ok = account.Reports[ts.Truncate(24*time.Hour)]; !ok {
 		return nil
 	}
-	if path, ok = report.pathByKind[kind]; !ok {
-		return nil
-	}
-	return &path
-}
-
-func (db *DB) GetPathForCustomerAccountLatestKind(customerID, accountID, kind string) *string {
-	var (
-		customer Customer
-		account  Account
-		report   LocalReport
-		path     string
-		ok       bool
-	)
-	if customer, ok = db.Customers[customerID]; !ok {
-		return nil
-	}
-	if account, ok = customer.Accounts[accountID]; !ok {
-		return nil
-	}
-	report = account.Latest()
 	if path, ok = report.pathByKind[kind]; !ok {
 		return nil
 	}

--- a/core/reports.go
+++ b/core/reports.go
@@ -388,14 +388,21 @@ func loadReport(in io.Reader, c Collector) error {
 	return nil
 }
 
+// Collector describes record-aggregating recievers. A Collector implementation should collect a
+// specific type of record. For example a ResourceAccessSummaryReport is a Collector that will
+// attempt to parse a ResourceAccessSummaryReportItem from the provided string slice and append
+// that record to the report's internal aggregation.
 type Collector interface {
 	Collect(in []string) error
 }
 
+// ResourceAccessSummaryReport is a ResourceAccessSummaryReportItem collector.
 type ResourceAccessSummaryReport struct {
 	Items []ResourceAccessSummaryReportItem
 }
 
+// Collect will attempt to parse a ResourceAccessSummaryReportItem and append it to the
+// ResourceAccessSummaryReport internal aggregation.
 func (r *ResourceAccessSummaryReport) Collect(in []string) error {
 	ri, err := DecodeResourceAccessSummaryReportItem(in)
 	if err != nil {
@@ -405,10 +412,13 @@ func (r *ResourceAccessSummaryReport) Collect(in []string) error {
 	return nil
 }
 
+// PrincipalAccessSummaryReport is a PrincipalAccessSummaryReportItem collector.
 type PrincipalAccessSummaryReport struct {
 	Items []PrincipalAccessSummaryReportItem
 }
 
+// Collect will attempt to parse a PrincipalAccessSummaryReportItem and append it to the
+// PrincipalAccessSummaryReport internal aggregation.
 func (r *PrincipalAccessSummaryReport) Collect(in []string) error {
 	ri, err := DecodePrincipalAccessSummaryReportItem(in)
 	if err != nil {
@@ -418,10 +428,13 @@ func (r *PrincipalAccessSummaryReport) Collect(in []string) error {
 	return nil
 }
 
+// PrincipalReport is a PrincipalReportItem collector.
 type PrincipalsReport struct {
 	Items []PrincipalsReportItem
 }
 
+// Collect will attempt to parse a PrincipalReportItem and append it to the
+// PrincipalReport internal aggregation.
 func (r *PrincipalsReport) Collect(in []string) error {
 	ri, err := DecodePrincipalsReportItem(in)
 	if err != nil {
@@ -431,10 +444,13 @@ func (r *PrincipalsReport) Collect(in []string) error {
 	return nil
 }
 
+// ResourceReport is a ResourceReportItem collector.
 type ResourcesReport struct {
 	Items []ResourcesReportItem
 }
 
+// Collect will attempt to parse a ResourceReportItem and append it to the
+// ResourceReport internal aggregation.
 func (r *ResourcesReport) Collect(in []string) error {
 	ri, err := DecodeResourcesReportItem(in)
 	if err != nil {

--- a/core/reports.go
+++ b/core/reports.go
@@ -106,24 +106,9 @@ func LoadResourcesReport(in io.Reader) ([]ResourcesReportItem, error) {
 		return ts, &IllegalArgumentError{`in`, `invalid input`}
 	}
 
-	rr := csv.NewReader(in)
-	records, err := rr.ReadAll()
-	if err != nil {
-		return ts, err
-	}
-
-	for i, v := range records {
-		// skip the header row
-		if i == 0 {
-			continue
-		}
-		ri, err := DecodeResourcesReportItem(v)
-		if err != nil {
-			return ts, err
-		}
-		ts = append(ts, ri)
-	}
-	return ts, nil
+	collector := &ResourcesReport{Items: []ResourcesReportItem{}}
+	err := loadReport(in, collector)
+	return collector.Items, err
 }
 
 // LoadPrincipalsReport reads CSV from the provided reader.
@@ -380,6 +365,19 @@ type PrincipalsReport struct {
 
 func (r *PrincipalsReport) Collect(in []string) error {
 	ri, err := DecodePrincipalsReportItem(in)
+	if err != nil {
+		return err
+	}
+	r.Items = append(r.Items, ri)
+	return nil
+}
+
+type ResourcesReport struct {
+	Items []ResourcesReportItem
+}
+
+func (r *ResourcesReport) Collect(in []string) error {
+	ri, err := DecodeResourcesReportItem(in)
 	if err != nil {
 		return err
 	}

--- a/core/reports.go
+++ b/core/reports.go
@@ -154,18 +154,18 @@ func LoadPrincipalsReport(in io.Reader) ([]PrincipalsReportItem, error) {
 }
 
 type ResourcesReportItem struct {
-	AnalysisTime time.Time
-	ResourceName string
-	ResourceARN  string
-	ResourceType string
+	AnalysisTime time.Time `csv:"analysis_time" json:"analysis_time"`
+	ResourceName string    `csv:"resource_name" json:"resource_name"`
+	ResourceARN  string    `csv:"resource_arn" json:"resource_arn"`
+	ResourceType string    `csv:"resource_type" json:"resource_type"`
 
-	ResourceTagBusinessUnit    string
-	ResourceTagEnvironment     string
-	ResourceTagOwner           string
-	ResourceTagConfidentiality string
-	ResourceTagIntegrity       string
-	ResourceTagAvailability    string
-	ResourceTags               string
+	ResourceTagBusinessUnit    string `csv:"resource_tag_business_unit" json:"resource_tag_business_unit"`
+	ResourceTagEnvironment     string `csv:"resource_tag_environment" json:"resource_tag_environment"`
+	ResourceTagOwner           string `csv:"resource_tag_owner" json:"resource_tag_owner"`
+	ResourceTagConfidentiality string `csv:"resource_tag_confidentiality" json:"resource_tag_confidentiality"`
+	ResourceTagIntegrity       string `csv:"resource_tag_integrity" json:"resource_tag_integrity"`
+	ResourceTagAvailability    string `csv:"resource_tag_availability" json:"resource_tag_availability"`
+	ResourceTags               string `csv:"resource_tags" json:"resource_tags"`
 }
 
 func (i ResourcesReportItem) Equivalent(t ResourcesReportItem) bool {

--- a/core/reports_test.go
+++ b/core/reports_test.go
@@ -35,7 +35,7 @@ func TestResourcesReportItemEquivalent(t *testing.T) {
 	}
 }
 
-func TestDecodeResourcesReportItem(t *testing.T) {
+func TestUnmarshalResourcesReportItem(t *testing.T) {
 	// 2021-06-11T20:54:08.112773+00:00,AccountAdminAccessRole-Sandbox,arn:aws:iam::139710491120:role/AccountAdminAccessRole-Sandbox,IAMRole,,,,,,,{}
 	// validTime, _ := time.Parse(time.RFC3339Nano, `2021-06-11T20:54:08.112773+00:00`)
 	cases := map[string]struct {
@@ -74,7 +74,7 @@ func TestDecodeResourcesReportItem(t *testing.T) {
 		},
 	}
 	for l, c := range cases {
-		o, err := DecodeResourcesReportItem(c.Fields)
+		o, err := UnmarshalResourcesReportItem(c.Fields)
 		if !c.Expected.Equivalent(o) {
 			t.Errorf("Case: %v, output does not match expectation %v vs %v", l, o, c.Expected)
 		}

--- a/views/display.go
+++ b/views/display.go
@@ -1,0 +1,24 @@
+package views
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func Display(stdout, stderr io.Writer, format string, report interface{}) {
+	switch format {
+	case `pdf`:
+	case `csv`:
+		WriteCSVTo(stdout, stderr, report)
+	case `tap`:
+	case `json`:
+		b, err := json.Marshal(report)
+		if err != nil {
+			fmt.Fprintln(stderr, `unable to marshal report to json`)
+		}
+		fmt.Fprintln(stdout, string(b))
+	default:
+		fmt.Fprintln(stderr, `invalid output type`)
+	}
+}


### PR DESCRIPTION
This PR adds: 

* `query principals`
* `query resources`
* `query principal-access`
* `query resource-access`

These features enable a user to query a target (or latest) principal or resource report by any combination of principal (or resource) ARNs or names.

Signed-off-by: Jeff Nickoloff <jeff@allingeek.com>

## Description


## How Has This Been Tested?

Extensive manual testing was performed in an environment with existing synchronized k9 reports.


## How are existing users impacted? What migration steps/scripts do we need?

There should be no breaking changes to the existing customer contract.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/k9securityio/k9cli/blob/main/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
