### PR TITLE
[feature] Added over-accessible resources and over-permissioned principals

### DIFF
--- a/cmd/const.go
+++ b/cmd/const.go
@@ -23,4 +23,11 @@ const (
 
 	FLAG_NAME  = `name`
 	FLAG_NAMES = `names`
+
+	FLAG_SERVICE  = `service`
+	FLAG_SERVICES = `services`
+
+	FLAG_MAX_ADMIN  = `max-admin`
+	FLAG_MAX_ADMINS = `max-admins`
+	FLAG_MAX_RWD    = `max-rwd`
 )

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -29,5 +29,7 @@ const (
 
 	FLAG_MAX_ADMIN  = `max-admin`
 	FLAG_MAX_ADMINS = `max-admins`
-	FLAG_MAX_RWD    = `max-rwd`
+	FLAG_MAX_READ   = `max-read`
+	FLAG_MAX_WRITE  = `max-write`
+	FLAG_MAX_DELETE = `max-delete`
 )

--- a/cmd/query_risks_overAccessibleResources.go
+++ b/cmd/query_risks_overAccessibleResources.go
@@ -162,7 +162,7 @@ type ResourceAccessSummary struct {
 	ResourceName string `csv:"resource_name" json:"resource_name"`
 	ResourceARN  string `csv:"resource_arn" json:"resource_arn"`
 
-	PrincipalsByCapability map[string][]Principal `json:"principals_by_capability"`
+	PrincipalsByCapability map[string][]Principal `csv:"principals_by_capability" json:"principals_by_capability"`
 }
 
 func BuildResourceAccessSummaries(stderr io.Writer,

--- a/cmd/query_risks_overAccessibleResources.go
+++ b/cmd/query_risks_overAccessibleResources.go
@@ -1,0 +1,211 @@
+/*
+Copyright © 2022 The K9CLI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd contains all cobra commands
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/k9securityio/k9-cli/core"
+	"github.com/k9securityio/k9-cli/views"
+	"github.com/spf13/cobra"
+)
+
+// queryRisksOverAccessibleResourcesCmd represents the risks command
+var queryRisksOverAccessibleResourcesCmd = &cobra.Command{
+	Use:     "over-accessible-resources",
+	Aliases: []string{`accessible`},
+	Short:   "Show over accessible resource risks",
+	Run: func(cmd *cobra.Command, args []string) {
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		stdout := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+		services, _ := cmd.Flags().GetStringSlice(FLAG_SERVICE)
+
+		maxAdmins, _ := cmd.Flags().GetInt(FLAG_MAX_ADMIN)
+		maxRWD, _ := cmd.Flags().GetInt(FLAG_MAX_RWD)
+
+		policy := AccessibilityPolicy{
+			MaxAdmins:          maxAdmins,
+			MaxReadWriteDelete: maxRWD}
+
+		var reportDateTime *time.Time
+		if len(analysisDate) > 0 {
+			td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+			if err != nil {
+				fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
+				os.Exit(1)
+			}
+			reportDateTime = &td
+		}
+
+		serviceMap := map[string]bool{}
+		for _, s := range services {
+			serviceMap[s] = true
+		}
+
+		DoQueryOverAccessibleResources(stdout, stderr,
+			reportHome, customerID, accountID, format,
+			reportDateTime,
+			verbose,
+			serviceMap,
+			policy)
+	},
+}
+
+func init() {
+	queryRisksCmd.AddCommand(queryRisksOverAccessibleResourcesCmd)
+
+	queryRisksOverAccessibleResourcesCmd.Flags().StringSlice(FLAG_SERVICE, []string{}, "A list of service names to evaluate")
+	queryRisksOverAccessibleResourcesCmd.MarkFlagRequired(FLAG_SERVICE)
+
+	queryRisksOverAccessibleResourcesCmd.Flags().Int(FLAG_MAX_ADMIN, 5, "The maximum number of principals with administrative access to a resource.")
+	queryRisksOverAccessibleResourcesCmd.Flags().Int(FLAG_MAX_RWD, 5, "The maximum number of principals with read + write + delete to a resource.")
+}
+
+func DoQueryOverAccessibleResources(stdout, stderr io.Writer,
+	reportHome, customerID, accountID, format string,
+	analysisDate *time.Time,
+	verbose bool,
+	services map[string]bool,
+	policy AccessibilityPolicy) {
+
+	// load the local report database
+	db, err := core.LoadLocalDB(reportHome)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
+	}
+
+	if verbose {
+		defer DumpDBStats(stderr, &db)
+	}
+
+	// determine the file name fo rthe desired report
+	path := db.GetPathForCustomerAccountTimeKind(customerID, accountID, analysisDate, core.REPORT_TYPE_PREFIX_RESOURCE_ACCESS_SUMMARIES)
+	if path == nil || len(*path) <= 0 {
+		fmt.Fprintf(stderr, "No report found for customer: %v account: %v date: %v\n", customerID, accountID, analysisDate)
+		os.Exit(1)
+	}
+
+	// get the report
+	lf, err := os.Open(*path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+	}
+	report := &core.ResourceAccessSummaryReport{}
+	err = core.LoadReport(lf, report)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+	}
+
+	if verbose {
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report.Items))
+	}
+
+	violations := []ResourceAccessSummary{}
+	summaries := BuildResourceAccessSummaries(stderr, report.Items, services, verbose)
+	for _, summary := range summaries {
+		if !policy.IsCompliant(summary) {
+			violations = append(violations, summary)
+		}
+	}
+
+	views.Display(stdout, stderr, format, violations)
+}
+
+type AccessibilityPolicy struct {
+	MaxAdmins          int
+	MaxReadWriteDelete int
+}
+
+func (p AccessibilityPolicy) IsCompliant(s ResourceAccessSummary) bool {
+	if len(s.PrincipalsByCapability[core.ACCESS_CAPABILITY_RESOURCE_ADMIN]) > p.MaxAdmins {
+		return false
+	}
+	// TODO implement maxRWD
+	return true
+}
+
+type Principal struct {
+	ARN  string `json:"principal_arn"`
+	Name string `json:"principal_name"`
+	Type string `json:"principal_type"`
+}
+
+type ResourceAccessSummary struct {
+	ServiceName  string `csv:"service_name" json:"service_name"`
+	ResourceName string `csv:"resource_name" json:"resource_name"`
+	ResourceARN  string `csv:"resource_arn" json:"resource_arn"`
+
+	PrincipalsByCapability map[string][]Principal `json:"principals_by_capability"`
+}
+
+func BuildResourceAccessSummaries(stderr io.Writer,
+	reportItems []core.ResourceAccessSummaryReportItem,
+	services map[string]bool,
+	verbose bool) []ResourceAccessSummary {
+
+	indexedSummaries := map[string]ResourceAccessSummary{}
+	for _, i := range reportItems {
+		var ok bool
+		if _, ok = services[i.ServiceName]; !ok {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "Skipping ReportItem for: %v, %v\n", i.ServiceName, i.ResourceARN)
+			}
+			continue
+		}
+		var summary ResourceAccessSummary
+		var principal Principal
+		var principalList []Principal
+		if summary, ok = indexedSummaries[i.ResourceARN]; !ok {
+			summary = ResourceAccessSummary{
+				ServiceName:            i.ServiceName,
+				ResourceName:           i.ResourceName,
+				ResourceARN:            i.ResourceARN,
+				PrincipalsByCapability: map[string][]Principal{},
+			}
+		}
+		principal = Principal{
+			ARN:  i.PrincipalARN,
+			Name: i.PrincipalName,
+			Type: i.PrincipalType,
+		}
+		if principalList, ok = summary.PrincipalsByCapability[i.AccessCapability]; !ok {
+			principalList = []Principal{}
+		}
+		principalList = append(principalList, principal)
+		summary.PrincipalsByCapability[i.AccessCapability] = principalList
+		indexedSummaries[i.ResourceARN] = summary
+	}
+
+	summaries := []ResourceAccessSummary{}
+	for _, v := range indexedSummaries {
+		summaries = append(summaries, v)
+	}
+	return summaries
+}

--- a/cmd/query_risks_overPermissionedPrincipals.go
+++ b/cmd/query_risks_overPermissionedPrincipals.go
@@ -86,7 +86,7 @@ func init() {
 	queryRisksOverPermissionedPrincipalsCmd.Flags().StringSlice(FLAG_SERVICE, []string{}, "A list of service names to evaluate")
 	queryRisksOverPermissionedPrincipalsCmd.MarkFlagRequired(FLAG_SERVICE)
 
-	queryRisksOverPermissionedPrincipalsCmd.Flags().Int(FLAG_MAX_ADMIN, 5, "The maximum number of resources to which a principal may have administrative access.")
+	queryRisksOverPermissionedPrincipalsCmd.Flags().Int(FLAG_MAX_ADMIN, 5, "The maximum number of resources to which a principal may have ADMIN access.")
 
 	queryRisksOverPermissionedPrincipalsCmd.Flags().Int(FLAG_MAX_READ, 5, "The maximum number of resources to which a principal may have READ access.")
 	queryRisksOverPermissionedPrincipalsCmd.Flags().Int(FLAG_MAX_WRITE, 5, "The maximum number of resources to which a principal may have WRITE access.")

--- a/cmd/query_risks_overPermissionedPrincipals.go
+++ b/cmd/query_risks_overPermissionedPrincipals.go
@@ -161,7 +161,7 @@ type PrincipalAccessSummary struct {
 	Name string `csv:"principal_name" json:"principal_name"`
 	Type string `csv:"principal_type" json:"principal_type"`
 
-	ResourceAccessByCapability map[string][]Resource `json:"resources_by_capability"`
+	ResourceAccessByCapability map[string][]Resource `csv:"resources_by_capability" json:"resources_by_capability"`
 }
 
 func BuildPrincipalAccessSummaries(stderr io.Writer, reportItems []core.PrincipalAccessSummaryReportItem, services map[string]bool, verbose bool) []PrincipalAccessSummary {

--- a/cmd/query_risks_overPermissionedPrincipals.go
+++ b/cmd/query_risks_overPermissionedPrincipals.go
@@ -1,0 +1,206 @@
+/*
+Copyright © 2022 The K9CLI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd contains all cobra commands
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/k9securityio/k9-cli/core"
+	"github.com/k9securityio/k9-cli/views"
+	"github.com/spf13/cobra"
+)
+
+// queryRisksOverPermissionedPrincipalsCmd represents the risks command
+var queryRisksOverPermissionedPrincipalsCmd = &cobra.Command{
+	Use:   "over-permissioned-principals",
+	Short: "Show over-permissioned principal risks",
+	Run: func(cmd *cobra.Command, args []string) {
+		verbose, _ := cmd.Flags().GetBool(FLAG_VERBOSE)
+		format, _ := cmd.Flags().GetString(FLAG_FORMAT)
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		analysisDate, _ := cmd.Flags().GetString(FLAG_ANALYSIS_DATE)
+		reportHome, _ := cmd.Flags().GetString(FLAG_REPORT_HOME)
+		stdout := cmd.OutOrStdout()
+		stderr := cmd.ErrOrStderr()
+		services, _ := cmd.Flags().GetStringSlice(FLAG_SERVICE)
+
+		maxAdmins, _ := cmd.Flags().GetInt(FLAG_MAX_ADMIN)
+		maxRWD, _ := cmd.Flags().GetInt(FLAG_MAX_RWD)
+
+		policy := CapabilityLimitPolicy{
+			AdminCap:           maxAdmins,
+			ReadWriteDeleteCap: maxRWD}
+
+		var reportDateTime *time.Time
+		if len(analysisDate) > 0 {
+			td, err := time.Parse(core.FILENAME_TIMESTAMP_ANALYSIS_DATE_LAYOUT, analysisDate)
+			if err != nil {
+				fmt.Fprintf(stderr, "invalid analysis-date: %v\n", analysisDate)
+				os.Exit(1)
+			}
+			reportDateTime = &td
+		}
+
+		serviceMap := map[string]bool{}
+		for _, s := range services {
+			serviceMap[s] = true
+		}
+
+		DoQueryOverPermissionedPrincipals(stdout, stderr,
+			reportHome, customerID, accountID, format,
+			reportDateTime,
+			verbose,
+			serviceMap,
+			policy)
+
+	},
+}
+
+func init() {
+	queryRisksCmd.AddCommand(queryRisksOverPermissionedPrincipalsCmd)
+
+	queryRisksOverPermissionedPrincipalsCmd.Flags().StringSlice(FLAG_SERVICE, []string{}, "A list of service names to evaluate")
+	queryRisksOverPermissionedPrincipalsCmd.MarkFlagRequired(FLAG_SERVICE)
+
+	queryRisksOverPermissionedPrincipalsCmd.Flags().Int(FLAG_MAX_ADMIN, 5, "The maximum number of resources to which a principal may have administrative access.")
+	queryRisksOverPermissionedPrincipalsCmd.Flags().Int(FLAG_MAX_RWD, 5, "The maximum number of resources to which a principal may have read + write + delete access.")
+}
+
+func DoQueryOverPermissionedPrincipals(stdout, stderr io.Writer,
+	reportHome, customerID, accountID, format string,
+	analysisDate *time.Time,
+	verbose bool,
+	services map[string]bool,
+	policy CapabilityLimitPolicy) {
+
+	// load the local report database
+	db, err := core.LoadLocalDB(reportHome)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to load local database, %v\n", err)
+		os.Exit(1)
+	}
+
+	if verbose {
+		defer DumpDBStats(stderr, &db)
+	}
+
+	// determine the file name fo rthe desired report
+	path := db.GetPathForCustomerAccountTimeKind(customerID, accountID, analysisDate, core.REPORT_TYPE_PREFIX_PRINCIPAL_ACCESS_SUMMARIES)
+	if path == nil || len(*path) <= 0 {
+		fmt.Fprintf(stderr, "No report found for customer: %v account: %v date: %v\n", customerID, accountID, analysisDate)
+		os.Exit(1)
+	}
+
+	// get the report
+	lf, err := os.Open(*path)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+	}
+	report := &core.PrincipalAccessSummaryReport{}
+	err = core.LoadReport(lf, report)
+	if err != nil {
+		fmt.Fprintf(stderr, "Unable to open the requested report: %v\n", err)
+		os.Exit(1)
+	}
+
+	if verbose {
+		fmt.Fprintf(stderr, "Target Analysis: %v, records: %v\n", analysisDate, len(report.Items))
+	}
+
+	violations := []PrincipalAccessSummary{}
+	summaries := BuildPrincipalAccessSummaries(stderr, report.Items, services, verbose)
+	for _, summary := range summaries {
+		if !policy.IsCompliant(summary) {
+			violations = append(violations, summary)
+		}
+	}
+
+	views.Display(stdout, stderr, format, violations)
+
+}
+
+type CapabilityLimitPolicy struct {
+	AdminCap           int
+	ReadWriteDeleteCap int
+}
+
+func (p CapabilityLimitPolicy) IsCompliant(s PrincipalAccessSummary) bool {
+	if len(s.ResourceAccessByCapability[core.ACCESS_CAPABILITY_RESOURCE_ADMIN]) > p.AdminCap {
+		return false
+	}
+	return true
+}
+
+type Resource struct {
+	ARN         string `json:"resource_arn"`
+	ServiceName string `json:"service_name"`
+}
+
+type PrincipalAccessSummary struct {
+	ARN  string `csv:"principal_arn" json:"principal_arn"`
+	Name string `csv:"principal_name" json:"principal_name"`
+	Type string `csv:"principal_type" json:"principal_type"`
+
+	ResourceAccessByCapability map[string][]Resource `json:"resources_by_capability"`
+}
+
+func BuildPrincipalAccessSummaries(stderr io.Writer, reportItems []core.PrincipalAccessSummaryReportItem, services map[string]bool, verbose bool) []PrincipalAccessSummary {
+	indexedSummaries := map[string]PrincipalAccessSummary{}
+	for _, i := range reportItems {
+		var ok bool
+		if _, ok = services[i.ServiceName]; !ok {
+			if verbose {
+				fmt.Fprintf(stderr, "Skipping ReportItem for: %v, %v\n", i.ServiceName, i.PrincipalARN)
+			}
+			continue
+		}
+
+		var summary PrincipalAccessSummary
+		var resource Resource
+		var resourceList []Resource
+		if summary, ok = indexedSummaries[i.PrincipalARN]; !ok {
+			summary = PrincipalAccessSummary{
+				ARN:                        i.PrincipalARN,
+				Name:                       i.PrincipalName,
+				Type:                       i.PrincipalType,
+				ResourceAccessByCapability: map[string][]Resource{},
+			}
+		}
+		resource = Resource{
+			ARN:         i.ResourceARN,
+			ServiceName: i.ServiceName,
+		}
+		if resourceList, ok = summary.ResourceAccessByCapability[i.AccessCapability]; !ok {
+			resourceList = []Resource{}
+		}
+		resourceList = append(resourceList, resource)
+		summary.ResourceAccessByCapability[i.AccessCapability] = resourceList
+		indexedSummaries[i.PrincipalARN] = summary
+	}
+
+	summaries := []PrincipalAccessSummary{}
+	for _, v := range indexedSummaries {
+		summaries = append(summaries, v)
+	}
+	return summaries
+}

--- a/core/const.go
+++ b/core/const.go
@@ -25,3 +25,11 @@ const (
 	DB_INDEX_POSITION_MONTH      = 6
 	DB_INDEX_POSITION_FILE       = 7
 )
+
+const (
+	ACCESS_CAPABILITY_RESOURCE_ADMIN = `administer-resource`
+	ACCESS_CAPABILITY_DELETE_DATA    = `delete-data`
+	ACCESS_CAPABILITY_READ_CONFIG    = `read-config`
+	ACCESS_CAPABILITY_READ_DATA      = `read-data`
+	ACCESS_CAPABILITY_WRITE_DATA     = `write-data`
+)


### PR DESCRIPTION
**Note**: I think maybe we might rename "over-permissioned" to "over-capable"

## Description

This change adds two new `risks` queries:

1. `over-accessible-resources`
2. `over-permissioned-principals`

These similar commands process resource access summary reports and principal access summary reports respectively. Each uses three specialty flags:

1. A list of strings called `services`
2. An int `max-admin`
3. Another int `max-rwd`

These queries will filter and report resources or principals that match the service qualifier, and violate the specified admin or read-write-delete limit.

```sh
k9 query risks over-accessible-resources \
    --customer_id C10001 \
    --account 720226181253 \
    --analysis-date 2022-06-14 \
    --format json \
    --service S3 \
    --max-admin 1 \
        | jq '.[].resource_arn'
```

```sh
k9 query risks over-permissioned-principals \
    --customer_id C10001 \
    --account 720226181253 \
    --analysis-date 2022-06-14 \
    --format json \
    --service S3 \
    --max-admin 2 \
        | jq '.[].principal_arn'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested. But the code is testable.

## How are existing users impacted? What migration steps/scripts do we need?

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] read the [CONTRIBUTION](https://github.com/k9securityio/k9cli/blob/main/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
