### PR TITLE
CLOUD-1387 trigger account analysis

### DIFF
--- a/cmd/analyze_account.go
+++ b/cmd/analyze_account.go
@@ -68,6 +68,5 @@ func init() {
 	viper.BindPFlag(`customer_id`, analyzeAccountCmd.Flags().Lookup(`customer_id`))
 
 	analyzeAccountCmd.Flags().String(`api`, ``, `K9 API to use for analysis`)
-	//analyzeAccountCmd.MarkFlagRequired(`customer_id`)
 	viper.BindPFlag(`api`, analyzeAccountCmd.Flags().Lookup(`api`))
 }

--- a/cmd/analyze_account.go
+++ b/cmd/analyze_account.go
@@ -24,14 +24,21 @@ import (
 	"github.com/spf13/viper"
 )
 
-// analyzeAccountCmd represents the account command
 var analyzeAccountCmd = &cobra.Command{
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("account called")
-		// client.AnalyzeAccount(cmd.Flag(`account`).Value))
-	},
 	Use:   "account",
-	Short: `Run an analysis on a the specified account`,
+	Short: `Analyze the specified account`,
+	Run: func(cmd *cobra.Command, args []string) {
+		stdout := cmd.OutOrStdout()
+
+		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
+		accountID, _ := cmd.Flags().GetString(FLAG_ACCOUNT)
+		apiHost, _ := cmd.Flags().GetString("api")
+		if apiHost == "" {
+			apiHost = "api.k9security.io"
+		}
+
+		fmt.Fprintf(stdout, "will analyze %v account %v using %v\n", customerID, accountID, apiHost)
+	},
 }
 
 func init() {
@@ -39,4 +46,12 @@ func init() {
 	analyzeAccountCmd.Flags().String(`account`, ``, "The AWS account number for analysis (required)")
 	analyzeAccountCmd.MarkFlagRequired(`account`)
 	viper.BindPFlag(`account`, analyzeAccountCmd.Flags().Lookup(`account`))
+
+	analyzeAccountCmd.Flags().String(`customer_id`, ``, `K9 customer ID that owns the account`)
+	analyzeAccountCmd.MarkFlagRequired(`customer_id`)
+	viper.BindPFlag(`customer_id`, analyzeAccountCmd.Flags().Lookup(`customer_id`))
+
+	analyzeAccountCmd.Flags().String(`api`, ``, `K9 API to use for analysis`)
+	//analyzeAccountCmd.MarkFlagRequired(`customer_id`)
+	viper.BindPFlag(`api`, analyzeAccountCmd.Flags().Lookup(`api`))
 }

--- a/cmd/analyze_account.go
+++ b/cmd/analyze_account.go
@@ -49,7 +49,11 @@ var analyzeAccountCmd = &cobra.Command{
 		}
 
 		fmt.Fprintf(stdout, "Starting analysis of %v account %v using %v\n", customerID, accountID, apiHost)
-		core.AnalyzeAccount(os.Stdout, cfg, apiHost, customerID, accountID)
+		err = core.AnalyzeAccount(os.Stdout, cfg, apiHost, customerID, accountID)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error triggering analysis for %v account %v: %v+\n", customerID, accountID, err)
+			os.Exit(1)
+		}
 	},
 }
 

--- a/cmd/analyze_account.go
+++ b/cmd/analyze_account.go
@@ -18,7 +18,11 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/k9securityio/k9-cli/core"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,6 +32,13 @@ var analyzeAccountCmd = &cobra.Command{
 	Use:   "account",
 	Short: `Analyze the specified account`,
 	Run: func(cmd *cobra.Command, args []string) {
+
+		cfg, err := config.LoadDefaultConfig(context.TODO())
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error retrieving AWS configuration: %v+\n", err)
+			os.Exit(1)
+		}
+
 		stdout := cmd.OutOrStdout()
 
 		customerID, _ := cmd.Flags().GetString(FLAG_CUSTOMER_ID)
@@ -37,7 +48,8 @@ var analyzeAccountCmd = &cobra.Command{
 			apiHost = "api.k9security.io"
 		}
 
-		fmt.Fprintf(stdout, "will analyze %v account %v using %v\n", customerID, accountID, apiHost)
+		fmt.Fprintf(stdout, "Starting analysis of %v account %v using %v\n", customerID, accountID, apiHost)
+		core.AnalyzeAccount(os.Stdout, cfg, apiHost, customerID, accountID)
 	},
 }
 

--- a/core/analyze.go
+++ b/core/analyze.go
@@ -68,8 +68,7 @@ func AnalyzeAccount(o io.Writer, cfg aws.Config, apiHost, customerID, account st
 		return err
 	}
 
-	client := &http.Client{}
-	response, err := client.Do(request)
+	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not execute API request: %s\n", err)
 		return err

--- a/core/analyze.go
+++ b/core/analyze.go
@@ -136,10 +136,10 @@ func createPayloadHash(req *http.Request) (string, error) {
 	}
 	var buf bytes.Buffer
 	_, err = buf.ReadFrom(body)
-
 	if err != nil {
 		return "", err
 	}
+	
 	b := sha256.Sum256(buf.Bytes())
 	return hex.EncodeToString(b[:]), nil
 }

--- a/core/analyze.go
+++ b/core/analyze.go
@@ -63,8 +63,7 @@ func AnalyzeAccount(o io.Writer, cfg aws.Config, apiHost, customerID, account st
 	request.Header.Set("Date", now.Format(time.RFC3339))
 	request.Header.Set("Content-Type", "application/json")
 
-	err = signApiRequest(cfg, request, now)
-	if err != nil {
+	if err != signApiRequest(cfg, request, now) {
 		fmt.Fprintf(os.Stderr, "Could not sign API request: %s\n", err)
 		return err
 	}
@@ -82,8 +81,7 @@ func AnalyzeAccount(o io.Writer, cfg aws.Config, apiHost, customerID, account st
 	responseBodyStr := string(body)
 	if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusAccepted {
 		analyzeResponse := analyzeResponseBody{}
-		err = json.Unmarshal(body, &analyzeResponse)
-		if err != nil {
+		if err != json.Unmarshal(body, &analyzeResponse) {
 			fmt.Fprintf(os.Stderr, "Could not deserialize API response: %s\n", responseBodyStr)
 			return err
 		}
@@ -93,7 +91,6 @@ func AnalyzeAccount(o io.Writer, cfg aws.Config, apiHost, customerID, account st
 			account,
 			analyzeResponse.ExecutionID)
 	} else {
-		//fmt.Println("response Headers:", response.Header)
 		fmt.Fprintf(os.Stderr,"Analyze API Response Status: %s\n", response.Status)
 		fmt.Fprintf(os.Stderr, "Could not start analysis for %s account %s.  API Response: %s\n",
 			customerID,
@@ -122,9 +119,7 @@ func signApiRequest(cfg aws.Config, request *http.Request, signingTime time.Time
 	}
 
 	signer := v4.NewSigner()
-	err = signer.SignHTTP(ctx, credentials, request, hash, "execute-api", cfg.Region, signingTime)
-
-	if err != nil {
+	if err != signer.SignHTTP(ctx, credentials, request, hash, "execute-api", cfg.Region, signingTime) {
 		return err
 	}
 

--- a/core/analyze.go
+++ b/core/analyze.go
@@ -1,0 +1,145 @@
+/*
+Copyright © 2022 The K9CLI Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"time"
+)
+
+type analyzeRequestBody struct {
+	CustomerID string `json:"customerId"`
+	Account    string `json:"accountId"`
+}
+
+// Example:
+// {"customerId": "C10000", "accountId": "139710491120", "executionId": "ondemand-C10000-139710491120-2022-09-15_TV49"}
+type analyzeResponseBody struct {
+	CustomerID string `json:"customerId"`
+	Account    string `json:"accountId"`
+	ExecutionID string `json:"executionId"`
+}
+
+func AnalyzeAccount(o io.Writer, cfg aws.Config, apiHost, customerID, account string) error {
+	url := fmt.Sprintf("https://%s/analysis/account", apiHost)
+
+	requestBody := analyzeRequestBody{
+		CustomerID: customerID,
+		Account:    account,
+	}
+	requestBodyBytes, _ := json.Marshal(requestBody)
+
+	request, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBodyBytes))
+	now := time.Now()
+	request.Header.Set("Date", now.Format(time.RFC3339))
+	request.Header.Set("Content-Type", "application/json")
+
+	err = signApiRequest(cfg, request, now)
+	if err != nil {
+		// Handle error.
+	}
+
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not execute API request: %s\n", err)
+		return err
+	} else {
+		defer response.Body.Close()
+	}
+
+	body, _ := ioutil.ReadAll(response.Body)
+	responseBodyStr := string(body)
+	if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusAccepted {
+		analyzeResponse := analyzeResponseBody{}
+		err = json.Unmarshal(body, &analyzeResponse)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Could not deserialize API response: %s\n", responseBodyStr)
+			return err
+		}
+
+		fmt.Fprintf(o, "Started analysis for %s account %s with execution ID: %s\n",
+			customerID,
+			account,
+			analyzeResponse.ExecutionID)
+	} else {
+		//fmt.Println("response Headers:", response.Header)
+		fmt.Fprintf(os.Stderr,"Analyze API Response Status: %s\n", response.Status)
+		fmt.Fprintf(os.Stderr, "Could not start analysis for %s account %s.  API Response: %s\n",
+			customerID,
+			account,
+			responseBodyStr)
+	}
+	return nil
+}
+
+// Sign a request to the k9 Security AWS API gateway endpoint with an AWS v4 signature
+// using the aws-sdk-go-v2 v4.SignHTTP function.
+//
+// The request should be fully-built and ready to send to the gateway.
+//
+// The provided request will be modified in place.
+func signApiRequest(cfg aws.Config, request *http.Request, signingTime time.Time) error {
+	ctx := context.TODO()
+	credentials, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return err
+	}
+
+	hash, err := createPayloadHash(request)
+	if err != nil {
+		return err
+	}
+
+	signer := v4.NewSigner()
+	err = signer.SignHTTP(ctx, credentials, request, hash, "execute-api", cfg.Region, signingTime)
+
+	if err != nil {
+		return err
+	}
+
+	// fmt.Printf("Authorization: %s\n", request.Header.Get("Authorization"))
+	return err
+}
+
+// Create a hex-encoded SHA256 hash of the request payload.  Use when calculating an AWS v4 signature.
+func createPayloadHash(req *http.Request) (string, error) {
+	// from https://github.com/yuizho/salon/blob/a159bcfeb263cb6502403f682c138286a2d7bb1f/backend/lambda/mutate-user/appsync/client.go
+	body, err := req.GetBody()
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(body)
+
+	if err != nil {
+		return "", err
+	}
+	b := sha256.Sum256(buf.Bytes())
+	return hex.EncodeToString(b[:]), nil
+}

--- a/core/analyze.go
+++ b/core/analyze.go
@@ -55,13 +55,18 @@ func AnalyzeAccount(o io.Writer, cfg aws.Config, apiHost, customerID, account st
 	requestBodyBytes, _ := json.Marshal(requestBody)
 
 	request, err := http.NewRequest("POST", url, bytes.NewBuffer(requestBodyBytes))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not build API request: %s\n", err)
+		return err
+	}
 	now := time.Now()
 	request.Header.Set("Date", now.Format(time.RFC3339))
 	request.Header.Set("Content-Type", "application/json")
 
 	err = signApiRequest(cfg, request, now)
 	if err != nil {
-		// Handle error.
+		fmt.Fprintf(os.Stderr, "Could not sign API request: %s\n", err)
+		return err
 	}
 
 	client := &http.Client{}


### PR DESCRIPTION
## Description

Customers can now trigger analysis of a monitored account on demand with the `k9 analyze account` command.

When you execute a command like:

```
k9 analyze account --customer_id C10001 --account 139710491120
```

The k9 API will authorize the request, trigger the analysis, and respond with the execution id of the analysis, e.g.:

```
Starting analysis of C10001 account 139710491120 using api.k9security.io
Started analysis for C10001 account 139710491120 with execution ID: ondemand-C10001-139710491120-2022-09-15_4KA5
```